### PR TITLE
Refactor changlog functions to allow multible calls to VundleChanglog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@
    "filetype plugin on
    "
    " Brief help
-   " :PluginList          - list configured plugins
-   " :PluginInstall(!)    - install (update) plugins
-   " :PluginSearch(!) foo - search (or refresh cache first) for foo
-   " :PluginClean(!)      - confirm (or auto-approve) removal of unused plugins
+   " :PluginList       - lists configured plugins
+   " :PluginInstall    - installs plugins; append `!` to update or just :PluginUpdate
+   " :PluginSearch foo - searches for foo; append `!` to refresh local cache
+   " :PluginClean      - confirms removal of unused plugins; append `!` to auto-approve removal
    "
    " see :h vundle for more details or wiki for FAQ
    " Put your non-Plugin stuff after this line

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
    If you are using Windows, go directly to [Windows setup]. If you run into any issues, please consult the [FAQ].
    See [Tips] for some advanced configurations.
 
+   Using non-POSIX shells, such as the popular Fish shell, requires additional setup. Please check the [FAQ].
+
 2. Set up [Vundle]:
 
    `$ git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [Vundle] is undergoing an [interface change], please stay up to date to get latest changes.
 
-[![Gitter-chat](https://badges.gitter.im/gmarik/Vundle.vim.png)](https://gitter.im/gmarik/Vundle.vim) for discussion and support.
+[![Gitter-chat](https://badges.gitter.im/gmarik/Vundle.vim.svg)](https://gitter.im/gmarik/Vundle.vim) for discussion and support.
 
 ![Vundle-installer](http://i.imgur.com/Rueh7Cc.png)
 

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -8,8 +8,8 @@
 com! -nargs=+  -bar   Plugin
 \ call vundle#config#bundle(<args>)
 
-com! -nargs=? -bang -complete=custom,vundle#scripts#complete PluginInstall
-\ call vundle#installer#new('!' == '<bang>', <q-args>)
+com! -nargs=* -bang -complete=custom,vundle#scripts#complete PluginInstall
+\ call vundle#installer#new('!' == '<bang>', <f-args>)
 
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete PluginSearch
 \ call vundle#scripts#all('!' == '<bang>', <q-args>)
@@ -24,7 +24,7 @@ com! -nargs=0         PluginDocs
 \ call vundle#installer#helptags(g:bundles)
 
 " Aliases
-com! PluginUpdate PluginInstall!
+com! -nargs=* -complete=custom,vundle#scripts#complete PluginUpdate PluginInstall! <args>
 
 " Vundle Aliases
 com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleInstall PluginInstall<bang> <args>

--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -32,6 +32,7 @@ com! -nargs=? -bang -complete=custom,vundle#scripts#complete VundleSearch  Plugi
 com! -nargs=? -bang                                          VundleClean   PluginClean<bang>
 com! -nargs=0                                                VundleDocs    PluginDocs
 com!                                                         VundleUpdate  PluginInstall!
+com! -nargs=*       -complete=custom,vundle#scripts#complete VundleUpdate  PluginInstall! <args>
 
 " Deprecated Commands
 com! -nargs=+                                                Bundle        call vundle#config#bundle(<args>)

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -6,9 +6,21 @@
 " ...    -- any number of bundle specifications (separate arguments)
 " ---------------------------------------------------------------------------
 func! vundle#installer#new(bang, ...) abort
-  let bundles = (a:1 == '') ?
-        \ g:bundles :
-        \ map(copy(a:000), 'vundle#config#bundle(v:val, {})')
+  " No specific plugins are specified. Operate on all plugins.
+  if a:0 == 0
+    let bundles = g:bundles
+  " Specific plugins are specified for update. Update them.
+  elseif (a:bang)
+    let bundles = filter(copy(g:bundles), 'index(a:000, v:val.name) > -1')
+  " Specific plugins are specified for installation. Install them.
+  else
+    let bundles = map(copy(a:000), 'vundle#config#bundle(v:val, {})')
+  endif
+
+  if empty(bundles)
+    echoerr 'No bundles were selected for operation'
+    return
+  endif
 
   let names = vundle#scripts#bundle_names(map(copy(bundles), 'v:val.name_spec'))
   call vundle#scripts#view('Installer',['" Installing plugins to '.expand(g:bundle_dir, 1)], names +  ['Helptags'])

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -36,13 +36,15 @@ endf
 "
 " a, c, d -- see :h command-completion-custom
 " return  -- all valid plugin names from vim-scripts.org as completion
-"            candidates, see also :h command-completion-custom
+"            candidates, or all installed plugin names when running an 'Update
+"            variant'. see also :h command-completion-custom
 " ---------------------------------------------------------------------------
 func! vundle#scripts#complete(a,c,d)
-  " Return only installed plugins if updating
-  if match(a:c, '\v^Plugin%(Install!|Update)') == 0
+  if match(a:c, '\v^%(Plugin|Vundle)%(Install!|Update)') == 0
+    " Only installed plugins if updating
     return join(map(copy(g:bundles), 'v:val.name'), "\n")
   else
+    " Or all known plugins otherwise
     return join(s:load_scripts(0),"\n")
   endif
 endf

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -39,7 +39,12 @@ endf
 "            candidates, see also :h command-completion-custom
 " ---------------------------------------------------------------------------
 func! vundle#scripts#complete(a,c,d)
-  return join(s:load_scripts(0),"\n")
+  " Return only installed plugins if updating
+  if match(a:c, '\v^Plugin%(Install!|Update)') == 0
+    return join(map(copy(g:bundles), 'v:val.name'), "\n")
+  else
+    return join(s:load_scripts(0),"\n")
+  endif
 endf
 
 

--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -70,6 +70,7 @@ endf
 " user.
 " ---------------------------------------------------------------------------
 func! s:create_changelog() abort
+  let changelog = ['Updated Plugins:']
   for bundle_data in g:updated_bundles
     let initial_sha = bundle_data[0]
     let updated_sha = bundle_data[1]
@@ -83,18 +84,19 @@ func! s:create_changelog() abort
 
     let updates = system(cmd)
 
-    call add(g:vundle_changelog, '')
-    call add(g:vundle_changelog, 'Updated Plugin: '.bundle.name)
+    call add(changelog, '')
+    call add(changelog, 'Updated Plugin: '.bundle.name)
 
     if bundle.uri =~ "https://github.com"
-      call add(g:vundle_changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
+      call add(changelog, 'Compare at: '.bundle.uri[0:-5].'/compare/'.initial_sha.'...'.updated_sha)
     endif
 
     for update in split(updates, '\n')
       let update = substitute(update, '\s\+$', '', '')
-      call add(g:vundle_changelog, '  '.update)
+      call add(changelog, '  '.update)
     endfor
   endfor
+  return changelog
 endf
 
 
@@ -102,14 +104,15 @@ endf
 " View the change log after an update or installation.
 " ---------------------------------------------------------------------------
 func! s:view_changelog()
-  call s:create_changelog()
-
-  if !exists('g:vundle_changelog_file')
-    let g:vundle_changelog_file = tempname()
+  if !exists('s:changelog_file')
+    let s:changelog_file = tempname()
   endif
 
-  call writefile(g:vundle_changelog, g:vundle_changelog_file)
-  execute 'silent pedit ' . g:vundle_changelog_file
+  if bufloaded(s:changelog_file)
+    execute 'silent bdelete' s:changelog_file
+  endif
+  call writefile(s:create_changelog(), s:changelog_file)
+  execute 'silent pedit' s:changelog_file
 
   wincmd P | wincmd H
 endf

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -244,8 +244,16 @@ PluginInstall allows installation of plugins by name:
 >
   :PluginInstall unite.vim
 
-Installs and activates unite.vim. You can use Tab to auto-complete known
-script names. Note that the installation just described isn't permanent. To
+Installs and activates unite.vim.
+
+PluginInstall also allows installation of several plugins separated by space.
+>
+  :PluginInstall tpope/vim-surround tpope/vim-fugitive
+
+Installs both tpope/vim-surround and tpope/vim-fugitive from GitHub.
+
+You can use Tab to auto-complete known script names.
+Note that the installation just described isn't permanent. To
 finish, you must put `Plugin 'unite.vim'` at the appropriate place in your
 `.vimrc` to tell Vundle to load the plugin at startup.
 
@@ -262,6 +270,12 @@ or >
 Installs or updates the configured plugins. Press 'u' after updates complete
 to see the change log of all updated bundles. Press 'l' (lowercase 'L') to
 see the log of commands if any errors occurred.
+
+To update specific plugins, write their names separated by space:
+>
+  :PluginInstall! vim-surround vim-fugitive
+or >
+  :PluginUpdate vim-surround vim-fugitive
 
 3.5 SEARCHING PLUGINS ~
                                       *vundle-plugins-search* *:PluginSearch*

--- a/test/minirc.vim
+++ b/test/minirc.vim
@@ -2,7 +2,8 @@ set nocompatible
 syntax on
 filetype off
 set rtp+=~/.vim/bundle/Vundle.vim/
-call vundle#rc()
-Bundle 'gmarik/Vundle.vim'
+call vundle#begin()
+Plugin 'gmarik/Vundle.vim'
+call vundle#end()
 filetype plugin indent on
 


### PR DESCRIPTION
Small bugfix. The bug appears when you have Vim running for a while, use `VundleChangelog` twice. Vim "hangs" with the cursor in the command line (at least with my settings for dialogs) because it tries to `silent pedit` a buffer that is loaded but changed in the background. The problem is [line 105](https://github.com/lucc/vundle/blob/8db3bcb5921103f0eb6de361c8b25cc03cb350b5/autoload/vundle/scripts.vim#L105).

To reproduce the bug try this:
1. open Vim
2. run `PluginUpdate`, afterwards press `u` to see the changelog
3. keep Vim open and `git reset --hard` one of your plugins to an outdated commit or tag (this will fool `PluginUpdate` to think that there are things to update)
4. run `PluginUpdate` again and press `u` afterwards. No Vim will "hang" (you can just press `ESC` or `CTRL-C`)

Note: These changes overlap with #450. Depending on which one will be merged first I can rebase the other one.