### PR TITLE
Fix for using Vundle in Windows setting g:bundle_dir to a network path

### DIFF
--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -198,6 +198,7 @@ func! s:rtp_add_a()
   let appends = join(paths, '/after,').'/after'
   exec 'set rtp^='.fnameescape(prepends)
   exec 'set rtp+='.fnameescape(appends)
+  let &rtp = substitute(&rtp, ',\\', ',\\\\', 'g')
 endf
 
 


### PR DESCRIPTION
I'm using Vundle on Windows setting g:bundle_dir to a network share (running Vim in a sort of a portable network mode).

When you do the 'set rtp +=' with the double backslashes, Vim is replacing them by a single backslash, causing the bundles loading to fail.

This line will fix the issue