### PR TITLE
Use `https` to alleviate potential mitm vulnerability

### DIFF
--- a/autoload/vundle/scripts.vim
+++ b/autoload/vundle/scripts.vim
@@ -211,7 +211,7 @@ func! s:fetch_scripts(to)
     call mkdir(scripts_dir, "p")
   endif
 
-  let l:vim_scripts_json = 'http://vim-scripts.org/api/scripts.json'
+  let l:vim_scripts_json = 'https://raw.githubusercontent.com/vim-scraper/vim-scraper.github.com/master/api/scripts.json'
   if executable("curl")
     let cmd = 'curl --fail -s -o '.vundle#installer#shellesc(a:to).' '.l:vim_scripts_json
   elseif executable("wget")


### PR DESCRIPTION
I've been contacted to address this issue, and quick fix would be using `https` protocol instead of `http`.

It's the same file just using straight from repo instead going through `vim-scrimts` domain.

UNTESTED.