### PR TITLE
Add option to allow locking a plugin to a specific revision

### DIFF
--- a/autoload/vundle.vim
+++ b/autoload/vundle.vim
@@ -53,6 +53,7 @@ if (has('signs'))
   sign define Vu_deleted  text=-  texthl=Comment
   sign define Vu_helptags text=*  texthl=Comment
   sign define Vu_pinned   text==  texthl=Comment
+  sign define Vu_detached text=@  texthl=Comment
 endif
 
 " Set up Vundle.  This function has to be called from the users vimrc file.

--- a/autoload/vundle/config.vim
+++ b/autoload/vundle/config.vim
@@ -278,4 +278,21 @@ func! s:bundle.is_pinned()
   return get(self, 'pinned')
 endf
 
+" ---------------------------------------------------------------------------
+" Return HEAD to the specified revision, if one exists, and check if 
+" it's detached
+"
+"  return -- 1 if the bundle is detached, 0 otherwise
+" ---------------------------------------------------------------------------
+func! s:bundle.is_detached()
+  let cmd = 'cd '.vundle#installer#shellesc(self.path())
+  let rev = get(self, 'rev', '')
+  if (rev != '')
+    let cmd = cmd.' && git checkout -q '.vundle#installer#shellesc(self.rev)
+  endif
+  let cmd = cmd.' && git status -b --porcelain'
+  let cmd = vundle#installer#shellesc_cd(cmd)
+  return system(cmd) =~# '^## HEAD'
+endf
+
 " vim: set expandtab sts=2 ts=2 sw=2 tw=78 norl:

--- a/autoload/vundle/installer.vim
+++ b/autoload/vundle/installer.vim
@@ -110,6 +110,8 @@ func! vundle#installer#run(func_name, name, ...) abort
     echo n.' regenerated'
   elseif 'pinned' == status
     echo n.' pinned'
+  elseif 'detached' == status
+    echo n. ' HEAD detached'
   elseif 'error' == status
     echohl Error
     echo 'Error processing '.n
@@ -416,6 +418,10 @@ func! s:make_sync_command(bang, bundle) abort
     let initial_sha = s:get_current_sha(a:bundle)
   else
     let cmd = 'git clone --recursive '.vundle#installer#shellesc(a:bundle.uri).' '.vundle#installer#shellesc(a:bundle.path())
+    let rev = get(a:bundle, 'rev', '')
+    if (rev != '')
+      let cmd = cmd.' -b '.vundle#installer#shellesc(rev)
+    endif
     let initial_sha = ''
   endif
   return [cmd, initial_sha]
@@ -439,6 +445,8 @@ func! s:sync(bang, bundle) abort
   " Do not sync if this bundle is pinned
   if a:bundle.is_pinned()
     return 'pinned'
+  elseif a:bundle.is_detached()
+    return 'detached'
   endif
 
   let [ cmd, initial_sha ] = s:make_sync_command(a:bang, a:bundle)

--- a/doc/vundle.txt
+++ b/doc/vundle.txt
@@ -189,6 +189,21 @@ control systems other than git, but the user is responsible for cloning and
 keeping up to date. It also allows the users to stay in the current version of
 a plugin that might have previously been updated by Vundle.
 
+The 'rev' option
+----------------
+
+The revision (branch or tag) you want to follow.
+
+For example:
+>
+  Plugin 'git_URI', 'branch or tag name'
+or
+>
+  Plugin 'git_URI', {'rev': 'branch or tag name'}
+
+Note that this option will try to checkout the revision specified
+everytime you install or update a plugin.
+
 Please note that the URI will be treated the same as for any other plugins, so
 only the last part of it will be added to the |runtimepath|. The user is
 advised to use this flag only with single word URIs to avoid confusion.


### PR DESCRIPTION
An attempt to, at least, start the 'lock to revision' feature.
I've run some tests, but I guess they were far from perfect.
Looking forward to bugs and ideas :smile: 

As a side effect, also takes care to mark and not to update "detached head" repositories.